### PR TITLE
Allow the component to be destroyed

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ import { NgProgressModule } from 'ngx-progressbar';
 })
 ```
 
-In your root component **(or any component that does not get destroyed)!**
+In your template
 
 ```html
 <ng-progress></ng-progress>

--- a/src/components/progress.component.ts
+++ b/src/components/progress.component.ts
@@ -1,5 +1,5 @@
 import {
-  Component, Input, ChangeDetectionStrategy, OnChanges, SimpleChanges, OnDestroy
+  Component, Input, ChangeDetectionStrategy, OnChanges, SimpleChanges
 } from '@angular/core';
 import { NgProgressService } from '../services/progress.service';
 
@@ -25,7 +25,7 @@ import { NgProgressService } from '../services/progress.service';
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 
-export class ProgressComponent implements OnChanges, OnDestroy {
+export class ProgressComponent implements OnChanges {
 
   /** Progress options  */
   @Input() ease = 'linear';
@@ -93,11 +93,6 @@ export class ProgressComponent implements OnChanges, OnDestroy {
         }
       }
     }
-  }
-
-  ngOnDestroy() {
-    this.progress.state.unsubscribe();
-    this.progress.trickling.unsubscribe();
   }
 
 }


### PR DESCRIPTION
This fix the javascript errors, ObjectUnsubscribedError,
that were thrown when navigating away from a page with
the progress bar to a page without the progress bar.

Fixes #27
Fixes #28
Fixes #33
Fixes #41
Fixes #81
Fixes #82