### PR TITLE
core missing metadata

### DIFF
--- a/lib/core/ng-package.json
+++ b/lib/core/ng-package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../../node_modules/ng-packagr/ng-package.schema.json",
   "lib": {
-    "entryFile": "./index.ts"
+    "entryFile": "./src/index.ts"
   },
   "dest": "../../build/core"
 }


### PR DESCRIPTION
Hi, this should fix the missing metadata inside the file core.metadata.json required for tslint (autocompletion)

Thanks for your time.
Have a nice day.