### PR TITLE
v4.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 4.1.1
+
+- Use rxjs deep imports to avoid the whole lib to be bundled, [#132](https://github.com/MurhafSousli/ngx-progressbar/pull/132).
+
 ## 4.1.0
 
 - feat(Support IE11): Remove css variable, closes [#123](https://github.com/MurhafSousli/ngx-progressbar/issues/123).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@ngx-progressbar/demo",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ngx-progressbar/demo",
   "description": "A nanoscopic progress bar. Featuring realistic trickle animations to convince your users that something is happening!",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",


### PR DESCRIPTION
Use rxjs deep imports to avoid the whole lib to be bundled, #132 