### PR TITLE
Add configuration for silent API request to ng-progress-http module.

### DIFF
--- a/projects/http/src/lib/ng-progress-http.interface.ts
+++ b/projects/http/src/lib/ng-progress-http.interface.ts
@@ -1,0 +1,3 @@
+export interface NgProgressHttpConfig {
+    silentApis?: string[];
+}

--- a/projects/http/src/lib/ng-progress-http.module.ts
+++ b/projects/http/src/lib/ng-progress-http.module.ts
@@ -1,10 +1,24 @@
-import { NgModule } from '@angular/core';
+import { NgModule, ModuleWithProviders } from '@angular/core';
 import { HTTP_INTERCEPTORS } from '@angular/common/http';
 import { NgProgressInterceptor } from './ng-progress.interceptor';
+import { NgProgressHttpConfig } from './ng-progress-http.interface';
+import { CONFIG } from './ng-progress-http.token';
+
+const defaultConfig: NgProgressHttpConfig = {
+  silentApis: []
+}
 
 @NgModule({
-  providers: [
-    { provide: HTTP_INTERCEPTORS, useClass: NgProgressInterceptor, multi: true }
-  ],
 })
-export class NgProgressHttpModule {}
+export class NgProgressHttpModule {
+  static forRoot(config?: NgProgressHttpConfig): ModuleWithProviders {
+    config = {...defaultConfig, ...config};
+    return {
+      ngModule: NgProgressHttpModule,
+      providers: [
+        { provide: CONFIG, useValue: config },
+        { provide: HTTP_INTERCEPTORS, useClass: NgProgressInterceptor, multi: true }
+      ]
+    };
+  }
+}

--- a/projects/http/src/lib/ng-progress-http.token.ts
+++ b/projects/http/src/lib/ng-progress-http.token.ts
@@ -1,0 +1,4 @@
+import { InjectionToken } from '@angular/core';
+import { NgProgressHttpConfig } from './ng-progress-http.interface';
+
+export const CONFIG = new InjectionToken<NgProgressHttpConfig>('config');

--- a/projects/http/src/lib/ng-progress.interceptor.ts
+++ b/projects/http/src/lib/ng-progress.interceptor.ts
@@ -1,19 +1,25 @@
-import { Injectable } from '@angular/core';
+import { Injectable, Optional, Inject } from '@angular/core';
 import { HttpInterceptor, HttpEvent, HttpHandler, HttpRequest } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { finalize } from 'rxjs/operators';
 import { NgProgress } from '@ngx-progressbar/core';
+import { NgProgressHttpConfig } from './ng-progress-http.interface';
+import { CONFIG } from './ng-progress-http.token';
 
 @Injectable()
 export class NgProgressInterceptor implements HttpInterceptor {
 
   private _inProgressCount = 0;
 
-  constructor(private _ngProgress: NgProgress) {
+  constructor(private _ngProgress: NgProgress, @Optional() @Inject(CONFIG) private _config?: NgProgressHttpConfig) {
   }
 
-  // Ignoring specific requests will be supported after this https://github.com/angular/angular/issues/18155
   intercept(req: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
+    // Ignore silent api requests
+    if (this.checkUrl(req)) {
+      return next.handle(req);
+    }
+
     this._inProgressCount++;
     if (!this._ngProgress.ref('root').isStarted) {
       this._ngProgress.start();
@@ -24,5 +30,15 @@ export class NgProgressInterceptor implements HttpInterceptor {
         this._ngProgress.complete();
       }
     }));
+  }
+
+  /**
+   * Check if request is silent.
+   * @param req request
+   */
+  private checkUrl(req: HttpRequest<any>) {
+    const url = req.url.toLowerCase();
+    const found = this._config.silentApis.find((u) => url.startsWith(u));
+    return !!found;
   }
 }


### PR DESCRIPTION
Configuration allow to silent api request to be ignored by progress bar.

// There was a thing with the `CONTRIBUTING.md`. Running task `link-core` will fails as the `VERSION` is not set yet. And running `set-version` will fails as it required all 3 module is built first. My work-around is to ignore any error in the `build.js`. Hope you fix that soon.