### PR TITLE
ci: test Node.js 8, 10 and 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,5 +9,9 @@ node_js:
 
 script: npm run build-core
 
+before_install:
+  - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.12.3
+  - export PATH=$HOME/.yarn/bin:$PATH
+
 cache:
   yarn: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,10 @@ dist: trusty
 
 language: node_js
 node_js:
+  - "node"
+  - "10"
   - "8"
+  - "6"
 
 script: npm run build-core
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ node_js:
   - "node"
   - "10"
   - "8"
-  - "6"
 
 script: npm run build-core
 


### PR DESCRIPTION
We should test all current LTS branches and also current stable.

See https://github.com/nodejs/Release/blob/master/README.md