### PR TITLE
fix(http): get a new progressRef after the current one has been destr…

### DIFF
--- a/projects/ngx-progressbar/http/src/ng-progress.interceptor.ts
+++ b/projects/ngx-progressbar/http/src/ng-progress.interceptor.ts
@@ -16,9 +16,8 @@ export class NgProgressInterceptor implements HttpInterceptor {
     silentApis: []
   };
 
-  constructor(ngProgress: NgProgress, @Optional() @Inject(NG_PROGRESS_HTTP_CONFIG) config?: NgProgressHttpConfig) {
+  constructor(protected ngProgress: NgProgress, @Optional() @Inject(NG_PROGRESS_HTTP_CONFIG) config?: NgProgressHttpConfig) {
     this._config = config ? {...this._config, ...config} : this._config;
-    this._progressRef = ngProgress.ref(this._config.id);
   }
 
   intercept(req: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
@@ -35,6 +34,7 @@ export class NgProgressInterceptor implements HttpInterceptor {
 
     this._inProgressCount++;
 
+    this._progressRef = this.ngProgress.ref(this._config.id);
     if (!this._progressRef.isStarted) {
       this._progressRef.start();
     }


### PR DESCRIPTION
Get a new progressRef in NgProgressInterceptor after the current one has been destroyed

Reproduction of problem on [stackblitz](https://stackblitz.com/edit/ngx-progressbar-at3a5q)
Steps:
1) Go to example
2) Click "Test Http Request" (progress bar is showing up)
3) Go back
4) Go to example
5) Click "Test Http Request" (progress bar not show up)